### PR TITLE
stack trace should show searched extensions

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -4,6 +4,7 @@ var path = require('path');
 var caller = require('./caller.js');
 var nodeModulesPaths = require('./node-modules-paths.js');
 var splitRe = process.platform === 'win32' ? /[\/\\]/ : /\//;
+var format = require('util').format;
 
 module.exports = function resolve (x, opts, cb) {
     if (typeof opts === 'function') {
@@ -43,7 +44,7 @@ module.exports = function resolve (x, opts, cb) {
         if (err) cb(err)
         else if (n) cb(null, n, pkg)
         else if (core[x]) return cb(null, x);
-        else cb(new Error("Cannot find module '" + x + "' from '" + y + "'"))
+        else cb(new Error(format("Cannot find module '%s' from '%s' with extension in %j", x, y, extensions)));
     });
     
     function onfile (err, m, pkg) {
@@ -52,7 +53,7 @@ module.exports = function resolve (x, opts, cb) {
         else loadAsDirectory(res, function (err, d, pkg) {
             if (err) cb(err)
             else if (d) cb(null, d, pkg)
-            else cb(new Error("Cannot find module '" + x + "' from '" + y + "'"))
+            else cb(new Error(format("Cannot find module '%s' from '%s' with extension in %j", x, y, extensions)))
         })
     }
     

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var caller = require('./caller.js');
 var nodeModulesPaths = require('./node-modules-paths.js');
+var format = require('util').format;
 
 module.exports = function (x, opts) {
     if (!opts) opts = {};
@@ -27,10 +28,10 @@ module.exports = function (x, opts) {
         var n = loadNodeModulesSync(x, y);
         if (n) return n;
     }
-    
+
     if (core[x]) return x;
     
-    throw new Error("Cannot find module '" + x + "' from '" + y + "'");
+    throw new Error(format("Cannot find module '%s' from '%s' with extension in %j", x, y, extensions));
     
     function loadAsFileSync (x) {
         if (isFile(x)) {

--- a/test/mock.js
+++ b/test/mock.js
@@ -33,11 +33,11 @@ test('mock', function (t) {
     });
     
     resolve('baz', opts('/foo/bar'), function (err, res) {
-        t.equal(err.message, "Cannot find module 'baz' from '/foo/bar'");
+        t.equal(err.message, "Cannot find module 'baz' from '/foo/bar' with extension in [\".js\"]");
     });
     
     resolve('../baz', opts('/foo/bar'), function (err, res) {
-        t.equal(err.message, "Cannot find module '../baz' from '/foo/bar'");
+        t.equal(err.message, "Cannot find module '../baz' from '/foo/bar' with extension in [\".js\"]");
     });
 });
 
@@ -74,11 +74,11 @@ test('mock from package', function (t) {
     });
     
     resolve('baz', opts('/foo/bar'), function (err, res) {
-        t.equal(err.message, "Cannot find module 'baz' from '/foo/bar'");
+        t.equal(err.message, "Cannot find module 'baz' from '/foo/bar' with extension in [\".js\"]");
     });
     
     resolve('../baz', opts('/foo/bar'), function (err, res) {
-        t.equal(err.message, "Cannot find module '../baz' from '/foo/bar'");
+        t.equal(err.message, "Cannot find module '../baz' from '/foo/bar' with extension in [\".js\"]");
     });
 });
 

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -31,7 +31,7 @@ test('async foo', function (t) {
     });
     
     resolve('foo', { basedir : dir }, function (err) {
-        t.equal(err.message, "Cannot find module 'foo' from '" + path.resolve(dir) + "'");
+        t.equal(err.message, "Cannot find module 'foo' from '" + path.resolve(dir) + "' with extension in [\".js\"]");
     });
 });
 
@@ -191,7 +191,7 @@ test('cup', function (t) {
     
     resolve('./cup', { basedir : dir, extensions : [ '.js' ] },
     function (err, res) {
-        t.equal(err.message, "Cannot find module './cup' from '" + path.resolve(dir) + "'");
+        t.equal(err.message, "Cannot find module './cup' from '" + path.resolve(dir) + "' with extension in [\".js\"]");
     });
 });
 
@@ -234,11 +234,11 @@ test('other path', function (t) {
     });
     
     resolve('root', { basedir : dir, }, function (err, res) {
-        t.equal(err.message, "Cannot find module 'root' from '" + path.resolve(dir) + "'");
+        t.equal(err.message, "Cannot find module 'root' from '" + path.resolve(dir) + "' with extension in [\".js\"]");
     });
     
     resolve('zzz', { basedir : dir, paths: [otherDir] }, function (err, res) {
-        t.equal(err.message, "Cannot find module 'zzz' from '" + path.resolve(dir) + "'");
+        t.equal(err.message, "Cannot find module 'zzz' from '" + path.resolve(dir) + "' with extension in [\".js\"]");
     });
 });
 


### PR DESCRIPTION
traces can be a little cryptic when we don't know what kinds of files `resolve` is searching for
