### PR TITLE
use alternate syntax since caret breaks old npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "tape test/*.js"
   },
   "devDependencies": {
-    "tape": "^3.5.0",
+    "tape": "3.x",
     "tap": "0.4.13"
   },
   "license": "MIT",


### PR DESCRIPTION
...and travis still uses old npm. CI has been failing [since 1.1.3](https://travis-ci.org/substack/node-resolve/builds/51124597)
would close #75 
