### PR TITLE
make travis use latest npm release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+before_install: npm i -g npm
 node_js:
   - 0.6
   - 0.8


### PR DESCRIPTION
Alternatively, just use the latest npm available when test runs.
would close #74
