### PR TITLE
Use path.dirname to walk up looking for a package.json

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -106,7 +106,7 @@ module.exports = function resolve (x, opts, cb) {
         isFile(pkgfile, function (err, ex) {
             // on err, ex is false
             if (!ex) return loadpkg(
-                dir.replace(/[\\\/]*[^\\\/]+[\\\/]*/, ''), cb
+                path.dirname(dir), cb
             );
             
             readFile(pkgfile, function (err, body) {

--- a/test/pathfilter.js
+++ b/test/pathfilter.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var resolve = require('../');
 
 test('#62: deep module references and the pathFilter', function(t){
-	t.plan(6);
+	t.plan(9);
     
 	var resolverDir = __dirname + '/pathfilter/deep_ref';
 	var pathFilter = function(pkg, x, remainder){
@@ -14,8 +14,17 @@ test('#62: deep module references and the pathFilter', function(t){
 	
 	resolve('deep/ref', { basedir : resolverDir }, function (err, res, pkg) {
         if (err) t.fail(err);
+
         t.equal(pkg.version, "1.2.3");
         t.equal(res, resolverDir + '/node_modules/deep/ref.js');
+    });
+
+    resolve('deep/deeper/ref', { basedir: resolverDir },
+    function(err, res, pkg) {
+      if(err) t.fail(err);
+      t.notEqual(pkg, undefined);
+      t.equal(pkg.version, "1.2.3");
+      t.equal(res, resolverDir + '/node_modules/deep/deeper/ref.js');
     });
     
     resolve('deep/ref', { basedir : resolverDir, pathFilter : pathFilter },

--- a/test/precedence.js
+++ b/test/precedence.js
@@ -3,13 +3,12 @@ var test = require('tape');
 var resolve = require('../');
 
 test('precedence', function (t) {
-    t.plan(3);
+    t.plan(2);
     var dir = path.join(__dirname, 'precedence/aaa');
     
     resolve('./', { basedir : dir }, function (err, res, pkg) {
         t.ifError(err);
         t.equal(res, path.join(dir, 'index.js'));
-        t.equal(pkg, undefined);
     });
 });
 

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -3,19 +3,17 @@ var test = require('tape');
 var resolve = require('../');
 
 test('async foo', function (t) {
-    t.plan(9);
+    t.plan(7);
     var dir = __dirname + '/resolver';
     
     resolve('./foo', { basedir : dir }, function (err, res, pkg) {
         if (err) t.fail(err);
         t.equal(res, dir + '/foo.js');
-        t.equal(pkg, undefined);
     });
     
     resolve('./foo.js', { basedir : dir }, function (err, res, pkg) {
         if (err) t.fail(err);
         t.equal(res, dir + '/foo.js');
-        t.equal(pkg, undefined);
     });
     
     resolve('./foo', { basedir : dir, package: { main: 'resolver' } }, function (err, res, pkg) {


### PR DESCRIPTION
This fixes async resolution when looking for a package.json file.
Previously a regex was being used that was not allowing the recursive
behavior the code is attempting. Replacing with path.dirname fixes the
issue.

Fixes #76