### PR TITLE
err.code = 'MODULE_NOT_FOUND'

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -42,7 +42,11 @@ module.exports = function resolve(x, options, callback) {
         if (err) cb(err);
         else if (n) cb(null, n, pkg);
         else if (core[x]) return cb(null, x);
-        else cb(new Error("Cannot find module '" + x + "' from '" + y + "'"));
+        else {
+            var err = new Error("Cannot find module '" + x + "' from '" + y + "'");
+            err.code = 'MODULE_NOT_FOUND';
+            cb(err);
+        }
     });
 
     function onfile(err, m, pkg) {
@@ -51,7 +55,11 @@ module.exports = function resolve(x, options, callback) {
         else loadAsDirectory(res, function (err, d, pkg) {
             if (err) cb(err);
             else if (d) cb(null, d, pkg);
-            else cb(new Error("Cannot find module '" + x + "' from '" + y + "'"));
+            else {
+                var err = new Error("Cannot find module '" + x + "' from '" + y + "'");
+                err.code = 'MODULE_NOT_FOUND';
+                cb(err);
+            }
         });
     }
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -34,7 +34,9 @@ module.exports = function (x, options) {
 
     if (core[x]) return x;
 
-    throw new Error("Cannot find module '" + x + "' from '" + y + "'");
+    var err = new Error("Cannot find module '" + x + "' from '" + y + "'");
+    err.code = 'MODULE_NOT_FOUND';
+    throw err;
 
     function loadAsFileSync(x) {
         if (isFile(x)) {

--- a/test/mock.js
+++ b/test/mock.js
@@ -3,7 +3,7 @@ var test = require('tape');
 var resolve = require('../');
 
 test('mock', function (t) {
-    t.plan(6);
+    t.plan(8);
 
     var files = {};
     files[path.resolve('/foo/bar/baz.js')] = 'beep';
@@ -34,15 +34,17 @@ test('mock', function (t) {
 
     resolve('baz', opts('/foo/bar'), function (err, res) {
         t.equal(err.message, "Cannot find module 'baz' from '" + path.resolve('/foo/bar') + "'");
+        t.equal(err.code, 'MODULE_NOT_FOUND');
     });
 
     resolve('../baz', opts('/foo/bar'), function (err, res) {
         t.equal(err.message, "Cannot find module '../baz' from '" + path.resolve('/foo/bar') + "'");
+        t.equal(err.code, 'MODULE_NOT_FOUND');
     });
 });
 
 test('mock from package', function (t) {
-    t.plan(6);
+    t.plan(8);
 
     var files = {};
     files[path.resolve('/foo/bar/baz.js')] = 'beep';
@@ -74,10 +76,12 @@ test('mock from package', function (t) {
 
     resolve('baz', opts('/foo/bar'), function (err, res) {
         t.equal(err.message, "Cannot find module 'baz' from '" + path.resolve('/foo/bar') + "'");
+        t.equal(err.code, 'MODULE_NOT_FOUND');
     });
 
     resolve('../baz', opts('/foo/bar'), function (err, res) {
         t.equal(err.message, "Cannot find module '../baz' from '" + path.resolve('/foo/bar') + "'");
+        t.equal(err.code, 'MODULE_NOT_FOUND');
     });
 });
 

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -3,7 +3,7 @@ var test = require('tape');
 var resolve = require('../');
 
 test('async foo', function (t) {
-    t.plan(9);
+    t.plan(10);
     var dir = path.join(__dirname, 'resolver');
 
     resolve('./foo', { basedir: dir }, function (err, res, pkg) {
@@ -32,6 +32,7 @@ test('async foo', function (t) {
 
     resolve('foo', { basedir: dir }, function (err) {
         t.equal(err.message, "Cannot find module 'foo' from '" + path.resolve(dir) + "'");
+        t.equal(err.code, 'MODULE_NOT_FOUND');
     });
 });
 
@@ -175,7 +176,7 @@ test('normalize', function (t) {
 });
 
 test('cup', function (t) {
-    t.plan(3);
+    t.plan(4);
     var dir = path.join(__dirname, 'resolver');
 
     resolve('./cup', { basedir: dir, extensions: ['.js', '.coffee'] }, function (err, res) {
@@ -190,6 +191,7 @@ test('cup', function (t) {
 
     resolve('./cup', { basedir: dir, extensions: ['.js'] }, function (err, res) {
         t.equal(err.message, "Cannot find module './cup' from '" + path.resolve(dir) + "'");
+        t.equal(err.code, 'MODULE_NOT_FOUND');
     });
 });
 
@@ -213,7 +215,7 @@ test('mug', function (t) {
 });
 
 test('other path', function (t) {
-    t.plan(4);
+    t.plan(6);
     var resolverDir = path.join(__dirname, 'resolver');
     var dir = path.join(resolverDir, 'bar');
     var otherDir = path.join(resolverDir, 'other_path');
@@ -230,10 +232,12 @@ test('other path', function (t) {
 
     resolve('root', { basedir: dir }, function (err, res) {
         t.equal(err.message, "Cannot find module 'root' from '" + path.resolve(dir) + "'");
+        t.equal(err.code, 'MODULE_NOT_FOUND');
     });
 
     resolve('zzz', { basedir: dir, paths: [otherDir] }, function (err, res) {
         t.equal(err.message, "Cannot find module 'zzz' from '" + path.resolve(dir) + "'");
+        t.equal(err.code, 'MODULE_NOT_FOUND');
     });
 });
 


### PR DESCRIPTION
When using node's `require.resolve` there's a [`err.code` property set on error objects](https://github.com/nodejs/node/blob/e11fe0c2777561827cdb7207d46b0917ef3c42a7/lib/module.js#L333).

This change adds the same to `err.code` property to errors objects to match node's behavior.
