### PR TITLE
Fix node_modules paths on Windows

### DIFF
--- a/lib/node-modules-paths.js
+++ b/lib/node-modules-paths.js
@@ -5,17 +5,19 @@ module.exports = function (start, opts) {
         ? [].concat(opts.moduleDirectory)
         : ['node_modules']
     ;
+
+    // ensure that `start` is an absolute path at this point,
+    // resolving against the process' current working directory
+    start = path.resolve(start);
+
     var prefix = '/';
     if (/^([A-Za-z]:)/.test(start)) {
         prefix = '';
     } else if (/^\\\\/.test(start)) {
         prefix = '\\\\';
     }
-    var splitRe = process.platform === 'win32' ? /[\/\\]/ : /\/+/;
 
-    // ensure that `start` is an absolute path at this point,
-    // resolving against the process' current working directory
-    start = path.resolve(start);
+    var splitRe = process.platform === 'win32' ? /[\/\\]/ : /\/+/;
 
     var parts = start.split(splitRe);
 


### PR DESCRIPTION
This change moves 'prefix' test to happen after the absolute path is
resolved. Without it, the prefix tests never actually fire when starting
with a relative path, and the resulting dirs all end up looking like
`[ '/C:..', '/C:...' ]` instead of `[ 'C:...', 'C:...' ]`