### PR TITLE
Fix resolution algorithm for optional paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/node-modules-paths.js
+++ b/lib/node-modules-paths.js
@@ -34,5 +34,5 @@ module.exports = function (start, opts) {
     if (process.platform === 'win32'){
         dirs[dirs.length-1] = dirs[dirs.length-1].replace(":", ":\\");
     }
-    return dirs.concat(opts.paths);
+    return opts.paths.concat(dirs);
 }


### PR DESCRIPTION
According to node's [source code](https://github.com/nodejs/node/blob/master/lib/module.js#L473-L478), custom paths have to be evaluated first (as it makes more sense), and then use the `node_modules` ones. I've tried creating a test but I'm not sure where to put it nor which naming logic do they follow.

Also added a `.gitignore` for free :smile: 