### PR TITLE
add process to core objects

### DIFF
--- a/lib/core.json
+++ b/lib/core.json
@@ -21,6 +21,7 @@
     "net",
     "os",
     "path",
+    "process",
     "punycode",
     "querystring",
     "readline",


### PR DESCRIPTION
It looks like `process` was added to the list of core require-able objects in iojs 1.0.0 (and is currently available in the latest versions of Node).

My use case: I'm using @benmosher's [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) module which [uses this](https://github.com/benmosher/eslint-plugin-import/blob/0a918b1ba138ffb2cb5e864ea2d4c659f197bf3c/resolvers/node/index.js#L8) to determine whether a require/import statement is for a core module.

Obviously, I could just use the global `process`, but I'd like to be able to stub out the implementation using [`proxyquire`](https://npmjs.com/package/proxyquire) for tests.

Let me know if you need anything else from me. Thanks!
