### PR TITLE
Create error outside process.nextTick

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -12,8 +12,9 @@ module.exports = function resolve (x, opts, cb) {
     }
     if (!opts) opts = {};
     if (typeof x !== 'string') {
+        var err = new TypeError('path must be a string');
         return process.nextTick(function () {
-            cb(new Error('path must be a string'));
+            cb(err);
         });
     }
     


### PR DESCRIPTION
This creates much more relevant stack traces for user input errors
