### PR TITLE
Add v8 to core modules list

### DIFF
--- a/lib/core.json
+++ b/lib/core.json
@@ -34,5 +34,6 @@
     "url",
     "util",
     "vm",
+    "v8",
     "zlib"
 ]


### PR DESCRIPTION
https://nodejs.org/dist/latest-v6.x/docs/api/v8.html

Not sure if this is appropriate since it's only been a core module since io.js 1.0. Maybe resolve needs to check different lists of core modules based on node version?