### PR TITLE
add '_http_server' to core.json

### DIFF
--- a/lib/core.json
+++ b/lib/core.json
@@ -16,6 +16,7 @@
     "fs",
     "http",
     "https",
+    "_http_server",
     "_linklist",
     "module",
     "net",


### PR DESCRIPTION
I am using facebook's [jest](https://github.com/facebook/jest), which uses `node-resolve`, plus I use node's `_http_server`

`node-resolve` will not find `_http_server` because it is not in `core.json` list.
