### PR TITLE
[Tests] [Refactor] refactor `node-modules-paths` and add tests.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,44 @@
+version: 1.0.{build}
+skip_branch_with_pr: true
+build: off
+
+environment:
+  matrix:
+    - nodejs_version: "7"
+    - nodejs_version: "6"
+    - nodejs_version: "5"
+    - nodejs_version: "4"
+    - nodejs_version: "3"
+    - nodejs_version: "2"
+    - nodejs_version: "1"
+    - nodejs_version: "0.12"
+    - nodejs_version: "0.10"
+    - nodejs_version: "0.8"
+    - nodejs_version: "0.6"
+matrix:
+  # fast_finish: true
+  allow_failures:
+    - nodejs_version: "0.6"
+
+platform:
+  - x86
+  - x64
+
+# Install scripts. (runs after repo cloning)
+install:
+ # Get the latest stable version of Node.js or io.js
+ - ps: Install-Product node $env:nodejs_version $env:platform
+ - IF %nodejs_version% EQU 0.6 npm -g install npm@1.3
+ - IF %nodejs_version% EQU 0.8 npm -g install npm@2
+ - set PATH=%APPDATA%\npm;%PATH%
+ #- IF %nodejs_version% NEQ 0.6 AND %nodejs_version% NEQ 0.8 npm -g install npm
+ # install modules
+ - npm install
+
+# Post-install test scripts.
+test_script:
+ # Output useful info for debugging.
+ - node --version
+ - npm --version
+ # run tests
+ - npm run tests-only

--- a/lib/node-modules-paths.js
+++ b/lib/node-modules-paths.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var parse = path.parse || require('path-parse');
 
 module.exports = function nodeModulesPaths(start, opts) {
     var modules = opts && opts.moduleDirectory
@@ -17,22 +18,18 @@ module.exports = function nodeModulesPaths(start, opts) {
         prefix = '\\\\';
     }
 
-    var splitRe = process.platform === 'win32' ? /[\/\\]/ : /\/+/;
+    var paths = [start];
+    var parsed = parse(start);
+    while (parsed.dir !== paths[paths.length - 1]) {
+        paths.push(parsed.dir);
+        parsed = parse(parsed.dir);
+    }
 
-    var parts = start.split(splitRe);
-
-    var dirs = [];
-    for (var i = parts.length - 1; i >= 0; i--) {
-        if (modules.indexOf(parts[i]) !== -1) continue;
-        dirs = dirs.concat(modules.map(function (module_dir) {
-            return prefix + path.join(prefix,
-                path.join.apply(path, parts.slice(0, i + 1)),
-                module_dir
-            );
+    var dirs = paths.reduce(function (dirs, aPath) {
+        return dirs.concat(modules.map(function (moduleDir) {
+            return path.join(prefix, aPath, moduleDir);
         }));
-    }
-    if (process.platform === 'win32') {
-        dirs[dirs.length - 1] = dirs[dirs.length - 1].replace(':', ':\\');
-    }
+    }, []);
+
     return opts && opts.paths ? dirs.concat(opts.paths) : dirs;
 };

--- a/package.json
+++ b/package.json
@@ -19,14 +19,18 @@
     "test": "npm run --silent tests-only"
   },
   "devDependencies": {
-    "tape": "^4.6.3",
+    "object-keys": "^1.0.11",
+    "safe-publish-latest": "^1.1.1",
     "tap": "0.4.13",
-    "safe-publish-latest": "^1.1.1"
+    "tape": "^4.6.3"
   },
   "license": "MIT",
   "author": {
     "name": "James Halliday",
     "email": "mail@substack.net",
     "url": "http://substack.net"
+  },
+  "dependencies": {
+    "path-parse": "^1.0.5"
   }
 }

--- a/test/faulty_basedir.js
+++ b/test/faulty_basedir.js
@@ -1,10 +1,7 @@
 var test = require('tape');
 var resolve = require('../');
 
-// not sure what's up with this test anymore
-if (process.platform !== 'win32') return;
-
-test('faulty basedir must produce error in windows', function (t) {
+test('faulty basedir must produce error in windows', { skip: process.platform !== 'win32' }, function (t) {
     t.plan(1);
 
     var resolverDir = 'C:\\a\\b\\c\\d';


### PR DESCRIPTION
 - Add `path-parse` since `node` <= 0.10 doesn’t have `path.parse`

This PR adds tests for `node-modules-paths`, and also makes them pass in Windows. In order to retain compatibility with node 0.10 and earlier, which lacks `path.parse`, I'm adding the `path-parse` dependency.

If we ever wish to drop 0.6, 0.8, and 0.10 compat, then we can drop the runtime dependency as well.

This should fix #106, may make #107 unnecessary, closes #52, and affects #88.

The `node-modules-paths` tests are a bit loose out of necessity - I didn't want to simply duplicate the implementation to test them, and since `$PWD` will differ across machines, I didn't want to couple the tests to a individual machine's paths.