### PR TITLE
[Fix] correctly resolve dir paths when file with the same name exists

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -34,7 +34,7 @@ module.exports = function resolve(x, options, callback) {
 
     if (/^(?:\.\.?(?:\/|$)|\/|([A-Za-z]:)?[/\\])/.test(x)) {
         var res = path.resolve(y, x);
-        if (x === '..') res += '/';
+        if (x === '..' || x.slice(-1) === '/') res += '/';
         if (/\/$/.test(x) && res === y) {
             loadAsDirectory(res, opts.package, onfile);
         } else loadAsFile(res, opts.package, onfile);

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -27,7 +27,7 @@ module.exports = function (x, options) {
 
     if (/^(?:\.\.?(?:\/|$)|\/|([A-Za-z]:)?[/\\])/.test(x)) {
         var res = path.resolve(y, x);
-        if (x === '..') res += '/';
+        if (x === '..' || x.slice(-1) === '/') res += '/';
         var m = loadAsFileSync(res) || loadAsDirectorySync(res);
         if (m) return m;
     } else {

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -278,3 +278,19 @@ test('#25: node modules with the same name as node stdlib modules', function (t)
         t.equal(res, path.join(resolverDir, 'node_modules/punycode/index.js'));
     });
 });
+
+test('#52 - incorrectly resolves module-paths like "./someFolder/" when there is a file of the same name', function (t) {
+    t.plan(2);
+
+    var dir = path.join(__dirname, 'resolver');
+
+    resolve('./foo', { basedir: path.join(dir, 'same_names') }, function (err, res, pkg) {
+        if (err) t.fail(err);
+        t.equal(res, path.join(dir, 'same_names/foo.js'));
+    });
+
+    resolve('./foo/', { basedir: path.join(dir, 'same_names') }, function (err, res, pkg) {
+        if (err) t.fail(err);
+        t.equal(res, path.join(dir, 'same_names/foo/index.js'));
+    });
+});

--- a/test/resolver/same_names/foo.js
+++ b/test/resolver/same_names/foo.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/test/resolver/same_names/foo/index.js
+++ b/test/resolver/same_names/foo/index.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/test/resolver_sync.js
+++ b/test/resolver_sync.js
@@ -204,3 +204,16 @@ test('#79 - re-throw non ENOENT errors from stat', function (t) {
     t.end();
 });
 
+test('#52 - incorrectly resolves module-paths like "./someFolder/" when there is a file of the same name', function (t) {
+    var dir = path.join(__dirname, 'resolver');
+
+    t.equal(
+        resolve.sync('./foo', { basedir: path.join(dir, 'same_names') }),
+        path.join(dir, 'same_names/foo.js')
+    );
+    t.equal(
+        resolve.sync('./foo/', { basedir: path.join(dir, 'same_names') }),
+        path.join(dir, 'same_names/foo/index.js')
+    );
+    t.end();
+});


### PR DESCRIPTION
The current behavior is not in line with node's implementation.

```js
require.resolve('./foo') // 'foo.js'
require.resolve('./foo/') // 'foo/index.js'

resolve.sync('./foo') // 'foo.js'
resolve.sync('./foo/') // 'foo.js'
```

It affects both, sync and async methods and I fixed both of them.

Related Jest issue with more details https://github.com/facebook/jest/issues/3199

Fixes #51. Closes #53.