### PR TITLE
Publish only required files

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,9 @@
   },
   "dependencies": {
     "path-parse": "^1.0.5"
-  }
+  },
+  "files": [
+    "lib",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
This PR removes unnecessary files (test, examples) when publishing to npm. Please see the npm docs on the [files key](https://docs.npmjs.com/files/package.json#files) in `package.json`.

**To see how this will be packaged without publishing, run:**
```
npm pack
# produces resolve-1.3.3.tgz
```

**Files that will be published with this PR:**
```
./index.js
./lib
./lib/async.js
./lib/caller.js
./lib/core.js
./lib/core.json
./lib/node-modules-paths.js
./lib/sync.js
./LICENSE
./package.json
./readme.markdown
```

Thanks for the awesome library!